### PR TITLE
Bump markupsafe

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ Flask==1.0.2
 idna==2.7
 itsdangerous==0.24
 Jinja2==2.10
-MarkupSafe==1.0
+MarkupSafe==1.1.1
 requests==2.19.1
 urllib3==1.23
 Werkzeug==0.14.1


### PR DESCRIPTION
rebble-weather fails to build due to markupsafe==1.0. Seems to be to do with this:
https://github.com/pypa/setuptools/issues/2017

Bumping to 1.1.1 fixes the issue.
Markupsafe has been bumped to 1.1.1 in other rws repos, so it seems this has already been caught